### PR TITLE
14-Use-STONJSON-instead-of-NeoJSON

### DIFF
--- a/src/BaselineOfPrismCodeDisplayer/BaselineOfPrismCodeDisplayer.class.st
+++ b/src/BaselineOfPrismCodeDisplayer/BaselineOfPrismCodeDisplayer.class.st
@@ -17,12 +17,11 @@ BaselineOfPrismCodeDisplayer >> baseline: spec [
 			"Dependencies"
 			self
 				seaside3: spec;
-				neoJSON: spec;
 				mocketry: spec.
 
 			"Packages"
 			spec
-				package: 'PrismCodeDisplayer-Core' with: [ spec requires: #('NeoJSON' 'PrismCodeDisplayer-Library') ];
+				package: 'PrismCodeDisplayer-Core' with: [ spec requires: #('PrismCodeDisplayer-Library') ];
 				package: 'PrismCodeDisplayer-Library' with: [ spec requires: #('Seaside3') ];
 				package: 'PrismCodeDisplayer-Demo' with: [ spec requires: #('PrismCodeDisplayer-Core') ];
 				package: 'PrismCodeDisplayer-Core-Tests' with: [ spec requires: #('PrismCodeDisplayer-Core' 'Mocketry') ].
@@ -39,11 +38,6 @@ BaselineOfPrismCodeDisplayer >> baseline: spec [
 { #category : #dependencies }
 BaselineOfPrismCodeDisplayer >> mocketry: spec [
 	spec baseline: 'Mocketry' with: [ spec repository: 'github://dionisiydk/Mocketry:v6.0.x' ]
-]
-
-{ #category : #dependencies }
-BaselineOfPrismCodeDisplayer >> neoJSON: spec [
-	spec baseline: 'NeoJSON' with: [ spec repository: 'github://svenvc/NeoJSON:v17/repository' ]
 ]
 
 { #category : #accessing }

--- a/src/PrismCodeDisplayer-Core/PrismComponent.class.st
+++ b/src/PrismCodeDisplayer-Core/PrismComponent.class.st
@@ -164,12 +164,12 @@ PrismComponent >> defineScrollCallbackOn: aPreTag url: url menuCallBack: menuCb 
 				on: [ :intervalRequest | 
 					| interval |
 					interval := intervalRequest substrings: ':'.
-					self lastIndexLoad: (interval at:2).
+					self lastIndexLoad: (interval at: 2).
 					self requestContext
 						respond: [ :response | 
 							response
 								nextPutAll:
-									(NeoJSONWriter
+									(STONJSON
 										toString:
 											(self
 												displayComputedSourceCodeOnUrl: url asString


### PR DESCRIPTION
Use STONJSON instead of NeoJSON since it is already in the image.

Fixes #14